### PR TITLE
fix(linked-list): insert in the middle bug

### DIFF
--- a/src/data-structures/linked-lists/linked-list.js
+++ b/src/data-structures/linked-lists/linked-list.js
@@ -96,7 +96,7 @@ class LinkedList {
       newNode.next = current; // <5>
 
       current.previous.next = newNode; // <6>
-      if (current.next) { current.next.previous = newNode; } // <7>
+      current.previous = newNode; // <7>
       this.size += 1;
       return newNode;
     }

--- a/src/data-structures/linked-lists/linked-list.spec.js
+++ b/src/data-structures/linked-lists/linked-list.spec.js
@@ -165,8 +165,12 @@ describe('LinkedList Test', () => {
       it('should insert at the middle', () => {
         const newNode = linkedList.add('middle', 1);
         expect(newNode.value).toBe('middle');
+        // checking the 4 surrounding links were updated
         expect(newNode.next.value).toBe('found');
         expect(newNode.previous.value).toBe(0);
+        expect(linkedList.get(0).next.value).toBe('middle');
+        expect(linkedList.get(2).previous.value).toBe('middle');
+
         expect(linkedList.size).toBe(3);
         expect(linkedList.first.value).toBe(0);
       });


### PR DESCRIPTION
When inserting an item on the middle of a linked list one reference was not being updated properly.

Fixes #8